### PR TITLE
checkbox勾选状态清除不掉

### DIFF
--- a/src/fieldcontainer.js
+++ b/src/fieldcontainer.js
@@ -212,6 +212,7 @@ var container = BUI.Component.Controller.extend([GroupValid],
           field.set('checked',true);
         }else{
           field.set('checked',false);
+          $(field.get("el")).prop('checked',false); //checkbox控件在显示上还是勾选的
         }
       }else{
         if(value == null){


### PR DESCRIPTION
field.set('checked',false);
$(field.get("el")).prop('checked',false); //checkbox控件在显示上还是勾选的

用jQuery操作checkbox，清除掉勾选状态
