### PR TITLE
#3 由于checkbox工作不正常发现的问题

### DIFF
--- a/src/fieldcontainer.js
+++ b/src/fieldcontainer.js
@@ -208,7 +208,7 @@ var container = BUI.Component.Controller.extend([GroupValid],
       //如果是可勾选的
       if(field instanceof Field.Check){
         var fieldValue = field.get('value');
-        if(value && (fieldValue === value || (BUI.isArray(value) && BUI.Array.contains(fieldValue,value)))){
+        if(value !== undefined && (fieldValue == value || (BUI.isArray(value) && BUI.Array.contains(fieldValue,value)))){
           field.set('checked',true);
         }else{
           field.set('checked',false);


### PR DESCRIPTION
_setFieldValue 判断

value可以等于0或者null，将value改为value !== undefined
value可能和fieldValue类型不一致如，1和“1”，改为fieldValue == value

p.s. BUI.FormHelper.setFields并不是使用的bui对象，不能设置所有字段的值
